### PR TITLE
feat: integrate firebase user registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
+    "firebase": "^10.12.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/config/firebase-config.js
+++ b/src/config/firebase-config.js
@@ -1,0 +1,23 @@
+// Firebase configuration and initialization
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+
+// Configuration values are expected to be provided via environment variables
+// available through Vite's import.meta.env.
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
+};
+
+// Initialize Firebase app and commonly used services.
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+
+export { app, auth, db };
+


### PR DESCRIPTION
## Summary
- integrate Firebase config with auth and Firestore
- register users with createUserWithEmailAndPassword and store profile fields
- surface auth errors with toast notifications

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4ada3bfa883268dd183f8ddf422a8